### PR TITLE
form: saner ovo's

### DIFF
--- a/crown/src/kernel/form.rs
+++ b/crown/src/kernel/form.rs
@@ -311,14 +311,15 @@ impl Kernel {
         let stack = &mut self.serf.context.stack;
         self.serf.context.cache = Hamt::<Noun>::new(stack);
         let job_cell = job.as_cell().expect("serf: poke: job not a cell");
-        let job_data = job_cell.tail().as_cell().expect("serf: poke: data not a cell");
-        let job_wire = job_data.head();
+        let job_data = job_cell
+            .tail()
+            .as_cell()
+            .expect("serf: poke: data not a cell");
         let job_input = job_data.tail();
         let job_now = job_cell.head().as_atom().expect("serf: poke: now not atom");
         let now = inc(stack, job_now).as_noun();
         let wire = T(stack, &[D(0), D(tas!(b"arvo")), D(0)]);
         let crud = DirectAtom::new_panic(tas!(b"crud"));
-        let num = DirectAtom::new(self.serf.event_num)?;
         let mut ovo = T(stack, &[now, wire, goof, job_input]);
         let trace_name = if self.serf.context.trace_info.is_some() {
             Some(Self::poke_trace_name(

--- a/crown/src/kernel/form.rs
+++ b/crown/src/kernel/form.rs
@@ -311,11 +311,15 @@ impl Kernel {
         let stack = &mut self.serf.context.stack;
         self.serf.context.cache = Hamt::<Noun>::new(stack);
         let job_cell = job.as_cell().expect("serf: poke: job not a cell");
+        let job_data = job_cell.tail().as_cell().expect("serf: poke: data not a cell");
+        let job_wire = job_data.head();
+        let job_input = job_data.tail();
         let job_now = job_cell.head().as_atom().expect("serf: poke: now not atom");
         let now = inc(stack, job_now).as_noun();
         let wire = T(stack, &[D(0), D(tas!(b"arvo")), D(0)]);
         let crud = DirectAtom::new_panic(tas!(b"crud"));
-        let mut ovo = T(stack, &[now, wire, crud.as_noun(), goof, job_cell.tail()]);
+        let num = DirectAtom::new(self.serf.event_num)?;
+        let mut ovo = T(stack, &[now, wire, goof, job_input]);
         let trace_name = if self.serf.context.trace_info.is_some() {
             Some(Self::poke_trace_name(
                 &mut self.serf.context.stack,
@@ -406,7 +410,7 @@ impl Kernel {
             IndirectAtom::new_raw_bytes(stack, 16, t_vec.as_slice().as_ptr()).normalize_as_atom()
         };
 
-        let event_num = D(1);
+        let event_num = D(self.serf.event_num + 1);
         let wire = T(stack, &[D(tas!(b"poke")), D(0)]);
         let poke = T(
             stack,


### PR DESCRIPTION
to fit:

```
+$  goof    [mote=term =tang]
+$  wire    path
+$  ovum    [=wire =input]
+$  crud    [=goof =input]
+$  input   [eny=@ our=@ux now=@da cause=*]
```