### PR TITLE
AtomExt add as_string, fix to_bytes_until_nul

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,7 +361,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "choo"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bytes",
  "clap 4.5.20",

--- a/crown/src/kernel/form.rs
+++ b/crown/src/kernel/form.rs
@@ -179,6 +179,7 @@ impl Kernel {
     ///
     /// Result containing the poke response or an error.
     pub fn do_poke(&mut self, job: Noun) -> Result<Noun> {
+        eprintln!("poke: {:?}", job);
         match self.soft(job, Some("poke".to_string())) {
             Ok(res) => {
                 let cell = res.as_cell().expect("serf: poke: +slam returned atom");

--- a/crown/src/nockapp/http_driver.rs
+++ b/crown/src/nockapp/http_driver.rs
@@ -127,8 +127,8 @@ pub fn http() -> IODriverFn {
                             let key_vec = header.head().as_atom()?;
                             let val_vec = header.tail().as_atom()?;
 
-                            if let Some(key) = key_vec.to_bytes_until_nul() {
-                                if let Some(val) = val_vec.to_bytes_until_nul() {
+                            if let Ok(key) = key_vec.to_bytes_until_nul() {
+                                if let Ok(val) = val_vec.to_bytes_until_nul() {
                                     header_vec.push((
                                         String::from_utf8(key)?,
                                         String::from_utf8(val)?,

--- a/crown/src/noun/extensions.rs
+++ b/crown/src/noun/extensions.rs
@@ -6,7 +6,6 @@ use crate::noun::slab::NounSlab;
 use bincode::{Decode, Encode};
 use bytes::Bytes;
 use core::str;
-use std::ffi::CStr;
 use std::iter::Iterator;
 use sword::noun::{Atom, IndirectAtom, NounAllocator, D};
 use sword::serialization::{cue, jam};

--- a/crown/src/noun/extensions.rs
+++ b/crown/src/noun/extensions.rs
@@ -5,6 +5,7 @@ use crate::{Noun, Result, ToBytes, ToBytesExt};
 use crate::noun::slab::NounSlab;
 use bincode::{Decode, Encode};
 use bytes::Bytes;
+use core::str;
 use std::ffi::CStr;
 use std::iter::Iterator;
 use sword::noun::{Atom, IndirectAtom, NounAllocator, D};
@@ -54,7 +55,8 @@ pub trait AtomExt {
     fn from_bytes<A: NounAllocator>(allocator: &mut A, bytes: &Bytes) -> Atom;
     fn from_value<A: NounAllocator, T: ToBytes>(allocator: &mut A, value: T) -> Result<Atom>;
     fn eq_bytes(self, bytes: impl AsRef<[u8]>) -> bool;
-    fn to_bytes_until_nul(self) -> Option<Vec<u8>>;
+    fn to_bytes_until_nul(self) -> Result<Vec<u8>>;
+    fn to_string(self) -> Result<String>;
 }
 
 impl AtomExt for Atom {
@@ -95,12 +97,14 @@ impl AtomExt for Atom {
         }
     }
 
-    fn to_bytes_until_nul(self) -> Option<Vec<u8>> {
-        if let Ok(cstr) = CStr::from_bytes_until_nul(self.as_bytes()) {
-            Some(cstr.to_bytes().to_vec())
-        } else {
-            None
-        }
+    fn to_bytes_until_nul(self) -> Result<Vec<u8>> {
+        let bytes = str::from_utf8(self.as_bytes())?;
+        Ok(bytes.trim_end_matches('\0').as_bytes().to_vec())
+    }
+
+    fn to_string(self) -> Result<String> {
+        let str = str::from_utf8(self.as_bytes())?;
+        Ok(str.trim_end_matches('\0').to_string())
     }
 }
 

--- a/crown/src/noun/extensions.rs
+++ b/crown/src/noun/extensions.rs
@@ -55,7 +55,7 @@ pub trait AtomExt {
     fn from_value<A: NounAllocator, T: ToBytes>(allocator: &mut A, value: T) -> Result<Atom>;
     fn eq_bytes(self, bytes: impl AsRef<[u8]>) -> bool;
     fn to_bytes_until_nul(self) -> Result<Vec<u8>>;
-    fn to_string(self) -> Result<String>;
+    fn as_string(self) -> Result<String>;
 }
 
 impl AtomExt for Atom {
@@ -101,7 +101,7 @@ impl AtomExt for Atom {
         Ok(bytes.trim_end_matches('\0').as_bytes().to_vec())
     }
 
-    fn to_string(self) -> Result<String> {
+    fn as_string(self) -> Result<String> {
         let str = str::from_utf8(self.as_bytes())?;
         Ok(str.trim_end_matches('\0').to_string())
     }


### PR DESCRIPTION
to_bytes_until_nul throws an error if the input has no trailing null characters in it. I fixed it and then added an as_string implementation to the trait for convenience.

example:

```
#[test]
fn test_from_bytes() {
    use sword::noun::D;
    use sword_macros::tas;
    let d = D(tas!(b"boundary")).as_atom().unwrap();
    d.to_bytes_until_nul().unwrap();
}
```