### PR TITLE
markdown driver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ yaque = "0.6.6"
 bitvec = "1.0.1"
 futures = "0.3.30"
 intmap = "2.0.0"
+termimad = "0.31.0"
 
 [profile.dev]
 # opt-level = 3

--- a/crown/Cargo.toml
+++ b/crown/Cargo.toml
@@ -26,6 +26,7 @@ intmap = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
 tempfile = { workspace = true }
+termimad = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-test = { workspace = true }

--- a/crown/src/drivers/markdown.rs
+++ b/crown/src/drivers/markdown.rs
@@ -1,11 +1,12 @@
-use crate::{nockapp::driver::{make_driver, IODriverFn}, AtomExt};
-use sword_macros::tas;
+use crate::nockapp::driver::{make_driver, IODriverFn};
+use crate::AtomExt;
 use sword::noun::D;
+use sword_macros::tas;
 
-use tracing::error;
 use termimad::MadSkin;
+use tracing::error;
 
-pub fn markdown_driver() -> IODriverFn {
+pub fn markdown() -> IODriverFn {
     make_driver(|handle| async move {
         let skin = MadSkin::default_dark();
 

--- a/crown/src/drivers/markdown.rs
+++ b/crown/src/drivers/markdown.rs
@@ -1,0 +1,38 @@
+use crate::{nockapp::driver::{make_driver, IODriverFn}, AtomExt};
+use sword_macros::tas;
+use sword::noun::D;
+
+use tracing::error;
+use termimad::MadSkin;
+
+pub fn markdown_driver() -> IODriverFn {
+    make_driver(|handle| async move {
+        let skin = MadSkin::default_dark();
+
+        loop {
+            match handle.next_effect().await {
+                Ok(effect) => {
+                    let Ok(effect_cell) = unsafe { effect.root() }.as_cell() else {
+                        continue;
+                    };
+                    if unsafe { effect_cell.head().raw_equals(D(tas!(b"markdown"))) } {
+                        let markdown_text = effect_cell.tail();
+
+                        let text = if let Ok(atom) = markdown_text.as_atom() {
+                            String::from_utf8_lossy(&atom.to_bytes_until_nul()?).to_string()
+                        } else {
+                            error!("Failed to convert markdown text to string");
+                            continue;
+                        };
+
+                        println!("{}", skin.term_text(&text));
+                    }
+                }
+                Err(e) => {
+                    error!("Error in markdown driver: {:?}", e);
+                    continue;
+                }
+            }
+        }
+    })
+}

--- a/crown/src/drivers/mod.rs
+++ b/crown/src/drivers/mod.rs
@@ -3,3 +3,4 @@ pub mod file;
 pub mod http;
 pub mod npc;
 pub mod one_punch;
+pub mod markdown;

--- a/crown/src/drivers/mod.rs
+++ b/crown/src/drivers/mod.rs
@@ -1,6 +1,6 @@
 pub mod exit;
 pub mod file;
 pub mod http;
+pub mod markdown;
 pub mod npc;
 pub mod one_punch;
-pub mod markdown;

--- a/crown/src/lib.rs
+++ b/crown/src/lib.rs
@@ -27,6 +27,7 @@ pub use utils::error::{CrownError, Result};
 pub use drivers::exit::exit as exit_driver;
 pub use drivers::file::file as file_driver;
 pub use drivers::http::http as http_driver;
+pub use drivers::markdown::markdown as markdown_driver;
 pub use drivers::npc::{npc_client as npc_client_driver, npc_listener as npc_listener_driver};
 pub use drivers::one_punch::one_punch_man as one_punch_driver;
 


### PR DESCRIPTION
### Markdown Driver

Adds a terminal-based markdown renderer driver that processes markdown text effects. The driver uses `termimad` to render markdown with ANSI color formatting in the terminal. When a `%markdown` effect containing UTF-8 text is received, it renders the formatted output to stdout.
