### PR TITLE
Small corrections to ctrl-c behavior, tracing

### DIFF
--- a/crown/src/nockapp/nockapp.rs
+++ b/crown/src/nockapp/nockapp.rs
@@ -153,7 +153,7 @@ impl NockApp {
 
         if self.cancel_token.is_cancelled() {
             info!("Cancel token received, exiting");
-            std::process::exit(0);
+            std::process::exit(1);
         }
 
         select!(

--- a/crown/src/nockapp/nockapp.rs
+++ b/crown/src/nockapp/nockapp.rs
@@ -10,7 +10,7 @@ use tokio::io::AsyncWriteExt;
 use tokio::sync::{broadcast, mpsc, AcquireError, Mutex, OwnedSemaphorePermit};
 use tokio::time::Duration;
 use tokio::{fs, select};
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, trace};
 
 pub struct NockApp {
     // Nock kernel
@@ -55,11 +55,10 @@ impl NockApp {
         let ctrl_c = tokio::signal::ctrl_c();
         let cancel_token = tokio_util::sync::CancellationToken::new();
 
-        let token = cancel_token.clone();
         tokio::task::spawn(async move {
             let _ = ctrl_c.await;
-            token.cancel();
             info!("ctrl_c registered");
+            std::process::exit(0);
         });
 
         Self {
@@ -178,7 +177,7 @@ impl NockApp {
                 let curr_event_num = self.kernel.serf.event_num;
                 let saved_event_num = self.watch_recv.borrow();
                 if curr_event_num <= *saved_event_num {
-                    debug!("Skipping save, event number has not changed from: {}", curr_event_num);
+                    trace!("Skipping save, event number has not changed from: {}", curr_event_num);
                     return Ok(())
                 }
                 drop(saved_event_num);

--- a/crown/src/nockapp/test.rs
+++ b/crown/src/nockapp/test.rs
@@ -223,8 +223,8 @@ mod tests {
         assert!(chk.event_num == valid.event_num);
     }
 
-    #[test]
-    fn test_jam_equality_stack() {
+    #[tokio::test]
+    async fn test_jam_equality_stack() {
         let (_temp, nockapp) = setup_nockapp("test-ker.jam");
         let mut kernel = nockapp.kernel;
         let mut arvo = kernel.serf.arvo.clone();
@@ -235,8 +235,8 @@ mod tests {
         unsafe { assert!(unifying_equality(stack, &mut arvo, &mut c)) }
     }
 
-    #[test]
-    fn test_jam_equality_slab() {
+    #[tokio::test]
+    async fn test_jam_equality_slab() {
         let (_temp, nockapp) = setup_nockapp("test-ker.jam");
         let kernel = nockapp.kernel;
         let mut slab = NounSlab::new();
@@ -247,8 +247,8 @@ mod tests {
         unsafe { assert!(slab_equality(slab.root(), c)) }
     }
 
-    #[test]
-    fn test_jam_equality_slab_stack() {
+    #[tokio::test]
+    async fn test_jam_equality_slab_stack() {
         let (_temp, nockapp) = setup_nockapp("test-ker.jam");
         let mut kernel = nockapp.kernel;
         let mut arvo = kernel.serf.arvo.clone();


### PR DESCRIPTION
- change snapshot not-changed message to trace logging level since it dominates the debug logs.
- ctrl-c now exits the process immediately without waiting. The rationale being that the user should be able to exit the app without waiting for nock processing to finish in the current event. I left the cancellation token inside of NockApp because we still want a way to gracefully shutdown the app from within the work() function.
