### PR TITLE
form, boot: parameter for existing state load

### DIFF
--- a/crown/src/kernel/form.rs
+++ b/crown/src/kernel/form.rs
@@ -449,6 +449,23 @@ impl Kernel {
 
         self.do_poke(poke)
     }
+
+    /// Loads a kernel with state from jammed bytes
+    pub fn load_with_kernel_state(
+        pma_dir: PathBuf,
+        jam_paths: JamPaths,
+        kernel_jam: &[u8],
+        state_jam: &[u8],
+        hot_state: &[HotEntry],
+        trace: bool,
+    ) -> Result<Self> {
+        let mut kernel = Self::load_with_hot_state(pma_dir, jam_paths, kernel_jam, hot_state, trace);
+        let state_noun = <Noun as NounExt>::cue_bytes_slice(&mut kernel.serf.stack(), state_jam)?;
+        let kernel_noun = kernel.serf.arvo;
+        let new_arvo = Serf::load(&mut kernel.serf.context, kernel_noun, state_noun)?;
+        kernel.serf.arvo = new_arvo;
+        Ok(kernel)
+    }
 }
 
 /// Represents the Serf, which maintains context and provides an interface to


### PR DESCRIPTION
adds an option to the boot cli parameters for specifying the path to kernel state as a jammed noun. if given, we load up the kernel as normal and then call the serf's load with the cued state, updating the kernel's arvo field with the result.