### PR TITLE
crown: add skip subscriber feature

### DIFF
--- a/crown/Cargo.toml
+++ b/crown/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 default = ["slog-tracing"]
 slog-tracing = []
 trait-alias = []
+skip-subscriber = []
 
 [dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
Forgot to add this feature to cargo earlier (allows you to skip creation of a default subscriber when writing NockApps with custom logging).