### PR TITLE
Factoring out the default subscriber in Crown

### DIFF
--- a/apps/choo/main.rs
+++ b/apps/choo/main.rs
@@ -92,8 +92,8 @@ async fn main() -> Result<(), Error> {
 }
 
 async fn initialize_nockapp(cli: ChooCli) -> Result<crown::nockapp::NockApp, Error> {
-    let mut nockapp = boot::setup(KERNEL_JAM, Some(cli.boot), &[], "choo")?;
-
+    let mut nockapp = boot::setup(KERNEL_JAM, Some(cli.boot.clone()), &[], "choo")?;
+    boot::init_default_tracing(&cli.boot.clone());
     let mut slab = NounSlab::new();
     let hoon_cord = Atom::from_value(&mut slab, HOON_TXT).unwrap().as_noun();
     let bootstrap_poke = T(&mut slab, &[D(tas!(b"boot")), hoon_cord]);

--- a/apps/http-app/main.rs
+++ b/apps/http-app/main.rs
@@ -16,7 +16,8 @@ struct TestCli {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = TestCli::parse();
     debug!("KERNEL_JAM len: {:?}", KERNEL_JAM.to_vec().len());
-    let mut http_app = boot::setup(KERNEL_JAM, Some(cli.boot), &[], "choo")?;
+    let mut http_app = boot::setup(KERNEL_JAM, Some(cli.boot.clone()), &[], "choo")?;
+    boot::init_default_tracing(&cli.boot.clone());
     http_app.add_io_driver(crown::http_driver()).await;
 
     loop {

--- a/apps/test-app/main.rs
+++ b/apps/test-app/main.rs
@@ -23,7 +23,8 @@ struct TestCli {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = TestCli::parse();
     debug!("KERNEL_JAM len: {:?}", KERNEL_JAM.to_vec().len());
-    let mut test_app = boot::setup(KERNEL_JAM, Some(cli.boot), &[], "test")?;
+    let mut test_app = boot::setup(KERNEL_JAM, Some(cli.boot.clone()), &[], "test")?;
+    boot::init_default_tracing(&cli.boot.clone());
     let poke = if cli.exit {
         D(tas!(b"inc-exit"))
     } else {

--- a/crown/Cargo.toml
+++ b/crown/Cargo.toml
@@ -7,7 +7,6 @@ edition.workspace = true
 default = ["slog-tracing"]
 slog-tracing = []
 trait-alias = []
-skip-subscriber = []
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crown/src/kernel/boot.rs
+++ b/crown/src/kernel/boot.rs
@@ -46,6 +46,16 @@ pub struct Cli {
     pub state_jam: Option<String>,
 }
 
+pub fn init_default_tracing(cli: &Cli) {
+    tracing_subscriber::registry()
+        .with(
+            fmt::layer()
+                .with_ansi(cli.color == ColorChoice::Auto || cli.color == ColorChoice::Always),
+        )
+        .with(EnvFilter::new(&cli.log_level))
+        .init();
+}
+
 pub fn setup(
     jam: &[u8],
     cli: Option<Cli>,
@@ -53,16 +63,6 @@ pub fn setup(
     name: &str,
 ) -> Result<NockApp, Box<dyn std::error::Error>> {
     let cli = cli.unwrap_or_else(|| Cli::parse());
-
-    if !cfg!(feature = "skip-subscriber") {
-        tracing_subscriber::registry()
-            .with(
-                fmt::layer()
-                    .with_ansi(cli.color == ColorChoice::Auto || cli.color == ColorChoice::Always),
-            )
-            .with(EnvFilter::new(&cli.log_level))
-            .init();
-    }
 
     let data_dir = default_data_dir(name);
     let pma_dir = data_dir.join("pma");


### PR DESCRIPTION
Crate features are a little too brittle for this, we aren't leveraging the compile-time exclusion of tracing and the set union semantics aren't workable for mutually exclusive crate features. Not a big deal, just need to let the user choose to use the default subscriber or not. This probably requires changing some code where `crown::kernel::boot::setup` is invoked to also stand up the default registry + subscriber.

A further elaboration of this would have a sub-function that configures and returns the subscriber but doesn't automatically initialize the global registry so that users can slot the ANSI color-aware subscriber into their own registry layers.