### PR TITLE
Synchronous, public peek and poke for testing

### DIFF
--- a/crown/src/drivers/one_punch.rs
+++ b/crown/src/drivers/one_punch.rs
@@ -122,7 +122,9 @@ async fn handle_effect(
     let eff = eff?;
     debug!("poke_once_driver: effect received: {:?}", eff);
 
-    let effect_cell = unsafe { eff.root() }.as_cell().unwrap();
+    // Split out root bindings so they don't get dropped early
+    let root = unsafe { eff.root() };
+    let effect_cell = root.as_cell().unwrap();
     if unsafe { effect_cell.head().raw_equals(D(tas!(b"npc"))) } {
         let npc_effect = effect_cell.tail();
         if let Ok(npc_effect_cell) = npc_effect.as_cell() {

--- a/crown/src/nockapp/nockapp.rs
+++ b/crown/src/nockapp/nockapp.rs
@@ -175,17 +175,19 @@ impl NockApp {
     }
 
     /// Peek at a noun in the kernel, blocking operation
-    #[instrument(skip(self))]
     pub fn peek_sync(&mut self, path: NounSlab) -> Result<NounSlab, NockAppError> {
+        trace!("About to copy to stack");
         let path_noun = path.copy_to_stack(self.kernel.serf.stack());
+        trace!("Peeking at noun: {:?}", path_noun);
         let peek_noun = self.kernel.peek(path_noun)?;
+        trace!("Peeked noun: {:?}", peek_noun);
         let mut res_slab = NounSlab::new();
         res_slab.copy_into(peek_noun);
+        trace!("Copied res_slab");
         Ok(res_slab)
     }
 
     /// Poke at a noun in the kernel, blocking operation
-    #[instrument(skip(self))]
     pub fn poke_sync(&mut self, poke: NounSlab) -> Result<Vec<NounSlab>, NockAppError> {
         let poke_noun = poke.copy_to_stack(self.kernel.serf.stack());
         let slab = NounSlab::new();

--- a/crown/src/nockapp/nockapp.rs
+++ b/crown/src/nockapp/nockapp.rs
@@ -12,7 +12,7 @@ use tokio::sync::{broadcast, mpsc, AcquireError, Mutex, OwnedSemaphorePermit};
 use tokio::time::Duration;
 use tokio::{fs, select};
 use tokio_util::task::TaskTracker;
-use tracing::{debug, error, info, trace};
+use tracing::{debug, error, info, instrument, trace};
 
 type NockAppResult = Result<(), NockAppError>;
 
@@ -174,13 +174,31 @@ impl NockApp {
         Ok(())
     }
 
-    // fn reset(&mut self) {
-    //     self.tasks.reopen();
-    //     let (shutdown_send, shutdown_recv) = tokio::sync::oneshot::channel();
-    //     self.shutdown_send = Some(shutdown_send);
-    //     self.shutdown_recv = shutdown_recv;
-    //     self.exit_status.store(false, Ordering::SeqCst);
-    // }
+    /// Peek at a noun in the kernel, blocking operation
+    #[instrument(skip(self))]
+    pub fn peek_sync(&mut self, path: NounSlab) -> Result<NounSlab, NockAppError> {
+        let path_noun = path.copy_to_stack(self.kernel.serf.stack());
+        let peek_noun = self.kernel.peek(path_noun)?;
+        let mut res_slab = NounSlab::new();
+        res_slab.copy_into(peek_noun);
+        Ok(res_slab)
+    }
+
+    /// Poke at a noun in the kernel, blocking operation
+    #[instrument(skip(self))]
+    pub fn poke_sync(&mut self, poke: NounSlab) -> Result<Vec<NounSlab>, NockAppError> {
+        let poke_noun = poke.copy_to_stack(self.kernel.serf.stack());
+        let slab = NounSlab::new();
+        let root = unsafe { slab.root() };
+        let effects = self.kernel.poke(root, poke_noun)?;
+        let mut effect_slabs = Vec::new();
+        for effect in effects.list_iter() {
+            let mut effect_slab = NounSlab::new();
+            effect_slab.copy_into(effect);
+            effect_slabs.push(effect_slab);
+        }
+        Ok(effect_slabs)
+    }
 
     /// Runs until the nockapp is done (returns exit 0 or an error)
     pub async fn run(&mut self) -> NockAppResult {

--- a/crown/src/nockapp/nockapp.rs
+++ b/crown/src/nockapp/nockapp.rs
@@ -12,7 +12,7 @@ use tokio::sync::{broadcast, mpsc, AcquireError, Mutex, OwnedSemaphorePermit};
 use tokio::time::Duration;
 use tokio::{fs, select};
 use tokio_util::task::TaskTracker;
-use tracing::{debug, error, info, instrument, trace};
+use tracing::{debug, error, info, trace};
 
 type NockAppResult = Result<(), NockAppError>;
 

--- a/crown/src/noun/slab.rs
+++ b/crown/src/noun/slab.rs
@@ -141,6 +141,15 @@ impl From<Noun> for NounSlab {
     }
 }
 
+impl <const N: usize> From<[Noun; N]> for NounSlab {
+    fn from(nouns: [Noun; N]) -> Self {
+        let mut slab = Self::new();
+        let new_root = sword::noun::T(&mut slab, &nouns);
+        slab.set_root(new_root);
+        slab
+    }
+}
+
 impl NounSlab {
     /// Make a new noun slab with D(0) as the root
     pub fn new() -> Self {

--- a/crown/src/noun/slab.rs
+++ b/crown/src/noun/slab.rs
@@ -133,6 +133,14 @@ impl Default for NounSlab {
     }
 }
 
+impl From<Noun> for NounSlab {
+    fn from(noun: Noun) -> Self {
+        let mut slab = Self::new();
+        slab.copy_into(noun);
+        slab
+    }
+}
+
 impl NounSlab {
     /// Make a new noun slab with D(0) as the root
     pub fn new() -> Self {

--- a/crown/src/noun/slab.rs
+++ b/crown/src/noun/slab.rs
@@ -141,7 +141,7 @@ impl From<Noun> for NounSlab {
     }
 }
 
-impl <const N: usize> From<[Noun; N]> for NounSlab {
+impl<const N: usize> From<[Noun; N]> for NounSlab {
     fn from(nouns: [Noun; N]) -> Self {
         let mut slab = Self::new();
         let new_root = sword::noun::T(&mut slab, &nouns);

--- a/crown/tests/integration.rs
+++ b/crown/tests/integration.rs
@@ -1,0 +1,48 @@
+use crown::kernel::checkpoint::JamPaths;
+use crown::kernel::form::Kernel;
+use crown::noun::slab::NounSlab;
+use crown::NockApp;
+use sword::noun::Slots;
+use tracing::debug;
+use tracing_test::traced_test;
+
+use std::fs;
+use std::path::Path;
+use std::time::Duration;
+use sword::noun::{Noun, D};
+use sword_macros::tas;
+use tempfile::TempDir;
+
+fn setup_nockapp(jam: &str) -> (TempDir, NockApp) {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    let snap_dir = temp_dir.path().to_path_buf();
+    let jam_paths = JamPaths::new(&snap_dir);
+    debug!("jam_paths: {:?}", jam_paths);
+    let jam_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("test-jams")
+        .join(jam);
+    let jam_bytes = fs::read(jam_path).expect(&format!("Failed to read {} file", jam));
+    let kernel = Kernel::load(snap_dir, jam_paths, &jam_bytes, false);
+    debug!("Finished kernel load");
+    (temp_dir, NockApp::new(kernel, Duration::from_secs(1)))
+}
+
+#[tokio::test]
+#[traced_test]
+#[cfg_attr(miri, ignore)]
+async fn test_sync_peek_and_poke() {
+    let (_temp, mut nockapp) = setup_nockapp("test-ker.jam");
+
+    for i in 1..4 {
+        let poke = D(tas!(b"inc")).into();
+        let _ = nockapp.poke_sync(poke).unwrap();
+        let peek: NounSlab = D(tas!(b"state")).into();
+        // res should be [~ ~ val]
+        let res = nockapp.peek_sync(peek).unwrap();
+        let root = unsafe { res.root() };
+        let val: Noun = root.slot(7).unwrap();
+        unsafe {
+            assert!(val.raw_equals(D(i)));
+        }
+    }
+}

--- a/crown/tests/integration.rs
+++ b/crown/tests/integration.rs
@@ -2,9 +2,8 @@ use crown::kernel::checkpoint::JamPaths;
 use crown::kernel::form::Kernel;
 use crown::noun::slab::NounSlab;
 use crown::NockApp;
-use sword::noun::{Slots, T};
-use tracing::{debug, info};
-use tracing_test::traced_test;
+use sword::noun::Slots;
+use tracing::debug;
 
 use std::fs;
 use std::path::Path;


### PR DESCRIPTION
Mostly for testing purposes so that an IO driver isn't always necessary.