### PR TITLE
nockapp: poke_sync should have a wire parameter

### DIFF
--- a/crown/src/nockapp/nockapp.rs
+++ b/crown/src/nockapp/nockapp.rs
@@ -188,11 +188,14 @@ impl NockApp {
     }
 
     /// Poke at a noun in the kernel, blocking operation
-    pub fn poke_sync(&mut self, poke: NounSlab) -> Result<Vec<NounSlab>, NockAppError> {
+    pub fn poke_sync(
+        &mut self,
+        wire: NounSlab,
+        poke: NounSlab,
+    ) -> Result<Vec<NounSlab>, NockAppError> {
+        let wire_noun = wire.copy_to_stack(self.kernel.serf.stack());
         let poke_noun = poke.copy_to_stack(self.kernel.serf.stack());
-        let slab = NounSlab::new();
-        let root = unsafe { slab.root() };
-        let effects = self.kernel.poke(root, poke_noun)?;
+        let effects = self.kernel.poke(wire_noun, poke_noun)?;
         let mut effect_slabs = Vec::new();
         for effect in effects.list_iter() {
             let mut effect_slab = NounSlab::new();

--- a/crown/tests/integration.rs
+++ b/crown/tests/integration.rs
@@ -1,5 +1,6 @@
 use crown::kernel::checkpoint::JamPaths;
 use crown::kernel::form::Kernel;
+use crown::nockapp::wire::{SystemWire, Wire};
 use crown::noun::slab::NounSlab;
 use crown::NockApp;
 use sword::noun::Slots;
@@ -32,7 +33,8 @@ async fn test_sync_peek_and_poke() {
     let (_temp, mut nockapp) = setup_nockapp("test-ker.jam");
     for i in 1..4 {
         let poke = D(tas!(b"inc")).into();
-        let _ = nockapp.poke_sync(poke).unwrap();
+        let wire = SystemWire.to_noun_slab();
+        let _ = nockapp.poke_sync(wire, poke).unwrap();
         let peek: NounSlab = [D(tas!(b"state")), D(0)].into();
         // res should be [~ ~ %0 val]
         let res = nockapp.peek_sync(peek);


### PR DESCRIPTION
all kernels now expect to be poked with both a wire and a cause.