### PR TITLE
removing NPC effect_res print, rename one_punch wire

### DIFF
--- a/crown/src/drivers/npc.rs
+++ b/crown/src/drivers/npc.rs
@@ -203,7 +203,6 @@ pub fn npc_client(stream: UnixStream) -> IODriverFn {
                     }
                 },
                 effect_res = handle.next_effect() => {
-                    debug!("effect_res: {:?}", effect_res);
                     let mut slab = effect_res?; // Closed error should error driver
                     let Ok(effect_cell) = unsafe { slab.root() }.as_cell() else {
                         continue;

--- a/crown/src/drivers/one_punch.rs
+++ b/crown/src/drivers/one_punch.rs
@@ -14,7 +14,7 @@ pub enum OnePunchWire {
 
 impl Wire for OnePunchWire {
     const VERSION: u64 = 1;
-    const SOURCE: &'static str = "one_punch";
+    const SOURCE: &'static str = "one-punch";
 
     fn to_noun_slab(&self) -> NounSlab {
         let mut slab = NounSlab::new();


### PR DESCRIPTION
The effect_res print can be too much when large messages are going over the NPC driver. If you need it, it should just be put in by hand.

Also, I renamed the `wire` for one punch driver from `one_punch` to `one-punch` to match Hoon style.